### PR TITLE
add restart and worker started messages

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,6 @@
+machine:
+  services:
+    - docker
+dependencies:
+  pre:
+    - pip install docker-py

--- a/lando_messaging/clients.py
+++ b/lando_messaging/clients.py
@@ -4,8 +4,10 @@ These send messages that will be recevied by MessageRouter.
 """
 from __future__ import absolute_import
 from lando_messaging.messaging import JobCommands
-from lando_messaging.messaging import StartJobPayload, CancelJobPayload, JobStepCompletePayload, JobStepErrorPayload
+from lando_messaging.messaging import StartJobPayload, RestartJobPayload, CancelJobPayload
+from lando_messaging.messaging import JobStepCompletePayload, JobStepErrorPayload
 from lando_messaging.messaging import StageJobPayload, RunJobPayload, StoreJobOutputPayload
+from lando_messaging.messaging import WorkerStartedPayload
 from lando_messaging.workqueue import WorkQueueClient
 
 
@@ -39,12 +41,27 @@ class LandoClient(object):
         """
         self.send(JobCommands.START_JOB, StartJobPayload(job_id))
 
+    def restart_job(self, job_id):
+        """
+        Continue processing job from it's current job step.
+        :param job_id: int: unique id for a job
+        """
+        self.send(JobCommands.RESTART_JOB, RestartJobPayload(job_id))
+
     def cancel_job(self, job_id):
         """
         Post a message in the queue that a running job be stopped.
         :param job_id: unique id for a job
         """
         self.send(JobCommands.CANCEL_JOB, CancelJobPayload(job_id))
+
+    def worker_started(self, worker_queue_name):
+        """
+        Post a message in the queue that a worker has just launched and will listen for commands.
+        This only sent when the VM starts up.
+        :param worker_queue_name: str: name of the AMQP queue for the worker who just launched
+        """
+        self.send(JobCommands.WORKER_STARTED, WorkerStartedPayload(worker_queue_name))
 
     def job_step_complete(self, job_request_payload):
         """

--- a/lando_messaging/messaging.py
+++ b/lando_messaging/messaging.py
@@ -10,8 +10,10 @@ class JobCommands(object):
     Names of all the commands that are sent through the queue.
     """
     START_JOB = 'start_job'                                  # webserver -> lando
+    RESTART_JOB = 'restart_job'                              # webserver -> lando
     CANCEL_JOB = 'cancel_job'                                # webserver -> lando and lando -> lando_worker
 
+    WORKER_STARTED = 'worker_started'                        # lando_worker -> lando
     STAGE_JOB = 'stage_job'                                  # lando -> lando_worker
     STAGE_JOB_COMPLETE = 'stage_job_complete'                # lando_worker -> lando
     STAGE_JOB_ERROR = 'stage_job_error'                      # lando_worker -> lando
@@ -28,7 +30,9 @@ class JobCommands(object):
 # Commands that lando will receive.
 LANDO_INCOMING_MESSAGES = [
     JobCommands.START_JOB,
+    JobCommands.RESTART_JOB,
     JobCommands.CANCEL_JOB,
+    JobCommands.WORKER_STARTED,
     JobCommands.STAGE_JOB_COMPLETE,
     JobCommands.STAGE_JOB_ERROR,
     JobCommands.RUN_JOB_COMPLETE,
@@ -102,6 +106,17 @@ class StartJobPayload(object):
         self.job_id = job_id
 
 
+class RestartJobPayload(object):
+    """
+    Payload that to be sent with JobCommands.RESTART_JOB to lando.
+    """
+    def __init__(self, job_id):
+        """
+        :param job_id: int: job id we want to have lando restart.
+        """
+        self.job_id = job_id
+
+
 class CancelJobPayload(object):
     """
     Payload that to be sent with JobCommands.CANCEL_JOB to lando.
@@ -111,6 +126,17 @@ class CancelJobPayload(object):
         :param job_id: int: job id we want to have lando cancel.
         """
         self.job_id = job_id
+
+
+class WorkerStartedPayload(object):
+    """
+    Payload that to be sent with JobCommands.WORKER_STARTED to lando.
+    """
+    def __init__(self, worker_queue_name):
+        """
+        :param worker_queue_name: str: name of the AMQP queue for the worker who just launched
+        """
+        self.worker_queue_name = worker_queue_name
 
 
 class StageJobPayload(object):

--- a/lando_messaging/tests/test_messaging.py
+++ b/lando_messaging/tests/test_messaging.py
@@ -21,8 +21,14 @@ class FakeLando(object):
     def start_job(self, payload):
         self.start_job_payload = payload
 
+    def restart_job(self, payload):
+        self.restart_job_payload = payload
+
     def cancel_job(self, payload):
         self.cancel_job_payload = payload
+
+    def worker_started(self, payload):
+        self.worker_started_payload = payload
 
     def stage_job_complete(self, payload):
         self.stage_job_complete_payload = payload
@@ -99,6 +105,11 @@ class TestMessagingAndClients(TestCase):
         lando_client.start_job(job_id=1)
         # Send message to fake_lando to cancel job 2
         lando_client.cancel_job(job_id=2)
+        # Send message to fake_lando to restart job 33
+        lando_client.restart_job(job_id=33)
+
+        # Send message to fake_lando that the worker VM has finished launching
+        lando_client.worker_started("test")
 
         # Messages sent to lando from a lando_worker after receiving a message from lando
         stage_job_payload = StageJobPayload(credentials=None, job_id=3, input_files=[], vm_instance_name='test')
@@ -122,6 +133,7 @@ class TestMessagingAndClients(TestCase):
         router.run()
         self.assertEqual(fake_lando.start_job_payload.job_id, 1)
         self.assertEqual(fake_lando.cancel_job_payload.job_id, 2)
+        self.assertEqual(fake_lando.restart_job_payload.job_id, 33)
 
         self.assertEqual(fake_lando.stage_job_complete_payload.job_id, 3)
         self.assertEqual(fake_lando.stage_job_error_payload.message, "Oops1")


### PR DESCRIPTION
restart job goes from bespin-api to lando to restart running a job
worker started will be sent from the lando_worker vm to lando when it starts up
this will improve the book keeping for create vm + staging right now they are combined.