### PR TITLE
Add WorkProgressQueue class to send progress to a rabbit exchange

### DIFF
--- a/lando_messaging/messaging.py
+++ b/lando_messaging/messaging.py
@@ -172,7 +172,7 @@ class RunJobPayload(object):
         self.job_id = job_id
         self.cwl_file_url = workflow.url
         self.workflow_object_name = workflow.object_name
-        self.input_json = workflow.input_json
+        self.input_json = workflow.job_order
         self.output_directory = workflow.output_directory
         self.vm_instance_name = vm_instance_name
         self.success_command = JobCommands.RUN_JOB_COMPLETE

--- a/lando_messaging/tests/test_messaging.py
+++ b/lando_messaging/tests/test_messaging.py
@@ -67,7 +67,7 @@ class FakeLandoWorker(object):
 
 class FakeWorkflow(object):
     def __init__(self):
-        self.input_json = ''
+        self.job_order = ''
         self.url = ''
         self.object_name = ''
         self.output_directory = ''

--- a/lando_messaging/tests/test_workqueue.py
+++ b/lando_messaging/tests/test_workqueue.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from unittest import TestCase
 from lando_messaging.dockerutil import DockerRabbitmq
-from lando_messaging.workqueue import WorkQueueConnection, WorkQueueProcessor, WorkQueueClient
+from lando_messaging.workqueue import WorkQueueConnection, WorkQueueProcessor, WorkQueueClient, WorkProgressQueue
 
 
 class FakeConfig(object):
@@ -74,4 +74,19 @@ class TestWorkQueue(TestCase):
         # Saves value for test_work_queue_processor
         self.two_value = payload
 
+
+class TestWorkProgressQueue(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rabbit_vm = DockerRabbitmq()
+        cls.config = FakeConfig(DockerRabbitmq.HOST, DockerRabbitmq.USER, DockerRabbitmq.PASSWORD)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.rabbit_vm.destroy()
+
+    def test_work_progress_queue_can_send_json_message(self):
+        wpq = WorkProgressQueue(self.config, "job_status")
+        result = wpq.send('{"job":16, "status":"GOOD"}')
+        self.assertEqual(True, result)
 


### PR DESCRIPTION
Adds WorkProgressQueue.send for sending a message to an exchange.
Will be used by lando to notify subscribers of progress with a job.
Also included Config/WorkQueueConfig to better document what config should look like.
