### PR TITLE
Pass job details to worker

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,4 +3,4 @@ machine:
     - docker
 dependencies:
   pre:
-    - pip install docker-py
+    - pip install -r devRequirements.txt

--- a/devRequirements.txt
+++ b/devRequirements.txt
@@ -1,2 +1,3 @@
 nose==1.3.7
 docker-py==1.10.6
+mock==2.0.0

--- a/lando_messaging/clients.py
+++ b/lando_messaging/clients.py
@@ -124,13 +124,6 @@ class LandoWorkerClient(object):
         payload = StoreJobOutputPayload(credentials, job_details, output_directory, vm_instance_name)
         self._send(JobCommands.STORE_JOB_OUTPUT, payload)
 
-    def cancel_job(self, job_id):
-        """
-        Request that the worker cancel a currently running job.
-        :param job_id: int: unique id for the job we want to cancel
-        """
-        self._send(JobCommands.CANCEL_JOB, job_id)
-
     def _send(self, command, payload):
         """
         Send a message over work queue to worker.

--- a/lando_messaging/clients.py
+++ b/lando_messaging/clients.py
@@ -94,34 +94,34 @@ class LandoWorkerClient(object):
         """
         self.work_queue_client = WorkQueueClient(config, queue_name)
 
-    def stage_job(self, credentials, job_id, input_files, vm_instance_name):
+    def stage_job(self, credentials, job_details, input_files, vm_instance_name):
         """
         Request that a job be staged on a worker(ie. download some files)
         :param credentials: jobapi.Credentials: user's credentials used to download input_files
-        :param job_id: int: unique id for this job
+        :param job_details: object: details about job(id, name, created date, workflow version)
         :param input_files: [InputFile]: list of files to download
         :param vm_instance_name: str: name of the instance lando_worker is running on (this passed back in the response)
         """
-        self._send(JobCommands.STAGE_JOB, StageJobPayload(credentials, job_id, input_files, vm_instance_name))
+        self._send(JobCommands.STAGE_JOB, StageJobPayload(credentials, job_details, input_files, vm_instance_name))
 
-    def run_job(self, job_id, workflow, vm_instance_name):
+    def run_job(self, job_details, workflow, vm_instance_name):
         """
         Execute a workflow on a worker.
-        :param job_id: int: unique id for this job
+        :param job_details: object: details about job(id, name, created date, workflow version)
         :param workflow: jobapi.Workflow: url to workflow and parameters to use
         :param vm_instance_name: name of the instance lando_worker is running on (this passed back in the response)
         """
-        self._send(JobCommands.RUN_JOB, RunJobPayload(job_id, workflow, vm_instance_name))
+        self._send(JobCommands.RUN_JOB, RunJobPayload(job_details, workflow, vm_instance_name))
 
-    def store_job_output(self, credentials, job_id, output_directory, vm_instance_name):
+    def store_job_output(self, credentials, job_details, output_directory, vm_instance_name):
         """
         Store the output of a finished job.
         :param credentials: jobapi.Credentials: user's credentials used to upload resulting files
-        :param job_id: int: unique id for this job
+        :param job_details: object: details about job(id, name, created date, workflow version)
         :param output_directory: jobapi.OutputDirectory: info about where we will upload the results
         :param vm_instance_name: name of the instance lando_worker is running on (this passed back in the response)
         """
-        payload = StoreJobOutputPayload(credentials, job_id, output_directory, vm_instance_name)
+        payload = StoreJobOutputPayload(credentials, job_details, output_directory, vm_instance_name)
         self._send(JobCommands.STORE_JOB_OUTPUT, payload)
 
     def cancel_job(self, job_id):

--- a/lando_messaging/messaging.py
+++ b/lando_messaging/messaging.py
@@ -143,15 +143,16 @@ class StageJobPayload(object):
     """
     Payload that to be sent with JobCommands.STAGE_JOB to lando_worker.
     """
-    def __init__(self, credentials, job_id, input_files, vm_instance_name):
+    def __init__(self, credentials, job_details, input_files, vm_instance_name):
         """
-        :param credentials: jobapi.Credentials: keys used to download files
-        :param job_id: int: job id we want to have lando download files for
+        :param job_details: object: details about job(id, name, created date, workflow version)
+        :param job_details: object: details about job(id, name, created date, workflow version)
         :param input_files: [InputFile]: list of files to download
         :param vm_instance_name: str: name of the instance lando_worker is running on (this passed back in the response)
         """
         self.credentials = credentials
-        self.job_id = job_id
+        self.job_id = job_details.id
+        self.job_details = job_details
         self.input_files = input_files
         self.vm_instance_name = vm_instance_name
         self.success_command = JobCommands.STAGE_JOB_COMPLETE
@@ -163,13 +164,14 @@ class RunJobPayload(object):
     """
     Payload that to be sent with JobCommands.RUN_JOB to lando_worker.
     """
-    def __init__(self, job_id, workflow, vm_instance_name):
+    def __init__(self, job_details, workflow, vm_instance_name):
         """
-        :param job_id: int: unique id for this job
+        :param job_details: object: details about job(id, name, created date, workflow version)
         :param workflow: jobapi.Workflow: url to workflow and parameters to use
         :param vm_instance_name: name of the instance lando_worker is running on (this passed back in the response)
         """
-        self.job_id = job_id
+        self.job_id = job_details.id
+        self.job_details = job_details
         self.cwl_file_url = workflow.url
         self.workflow_object_name = workflow.object_name
         self.input_json = workflow.job_order
@@ -184,15 +186,16 @@ class StoreJobOutputPayload(object):
     """
     Payload that to be sent with JobCommands.STORE_JOB_OUTPUT to lando_worker.
     """
-    def __init__(self, credentials, job_id, output_directory, vm_instance_name):
+    def __init__(self, credentials, job_details, output_directory, vm_instance_name):
         """
         :param credentials: jobapi.Credentials: user's credentials used to upload resulting files
-        :param job_id: int: unique id for this job
+        :param job_details: object: details about job(id, name, created date, workflow version)
         :param output_directory: jobapi.OutputDirectory: info about where we will upload the results
         :param vm_instance_name: name of the instance lando_worker is running on (this passed back in the response)
         """
         self.credentials = credentials
-        self.job_id = job_id
+        self.job_id = job_details.id
+        self.job_details = job_details
         self.dir_name = output_directory.dir_name
         self.project_id = output_directory.project_id
         self.dds_user_credentials = output_directory.dds_user_credentials

--- a/lando_messaging/messaging.py
+++ b/lando_messaging/messaging.py
@@ -146,7 +146,6 @@ class StageJobPayload(object):
     def __init__(self, credentials, job_details, input_files, vm_instance_name):
         """
         :param job_details: object: details about job(id, name, created date, workflow version)
-        :param job_details: object: details about job(id, name, created date, workflow version)
         :param input_files: [InputFile]: list of files to download
         :param vm_instance_name: str: name of the instance lando_worker is running on (this passed back in the response)
         """

--- a/lando_messaging/messaging.py
+++ b/lando_messaging/messaging.py
@@ -97,7 +97,7 @@ class MessageRouter(object):
 
 class StartJobPayload(object):
     """
-    Payload that to be sent with JobCommands.START_JOB to lando.
+    Payload to be sent with JobCommands.START_JOB to lando.
     """
     def __init__(self, job_id):
         """
@@ -108,7 +108,7 @@ class StartJobPayload(object):
 
 class RestartJobPayload(object):
     """
-    Payload that to be sent with JobCommands.RESTART_JOB to lando.
+    Payload to be sent with JobCommands.RESTART_JOB to lando.
     """
     def __init__(self, job_id):
         """
@@ -119,7 +119,7 @@ class RestartJobPayload(object):
 
 class CancelJobPayload(object):
     """
-    Payload that to be sent with JobCommands.CANCEL_JOB to lando.
+    Payload to be sent with JobCommands.CANCEL_JOB to lando.
     """
     def __init__(self, job_id):
         """
@@ -130,7 +130,7 @@ class CancelJobPayload(object):
 
 class WorkerStartedPayload(object):
     """
-    Payload that to be sent with JobCommands.WORKER_STARTED to lando.
+    Payload to be sent with JobCommands.WORKER_STARTED to lando.
     """
     def __init__(self, worker_queue_name):
         """
@@ -141,10 +141,11 @@ class WorkerStartedPayload(object):
 
 class StageJobPayload(object):
     """
-    Payload that to be sent with JobCommands.STAGE_JOB to lando_worker.
+    Payload to be sent with JobCommands.STAGE_JOB to lando_worker.
     """
     def __init__(self, credentials, job_details, input_files, vm_instance_name):
         """
+        :param credentials: jobapi.Credentials: keys used to download files
         :param job_details: object: details about job(id, name, created date, workflow version)
         :param input_files: [InputFile]: list of files to download
         :param vm_instance_name: str: name of the instance lando_worker is running on (this passed back in the response)
@@ -161,7 +162,7 @@ class StageJobPayload(object):
 
 class RunJobPayload(object):
     """
-    Payload that to be sent with JobCommands.RUN_JOB to lando_worker.
+    Payload to be sent with JobCommands.RUN_JOB to lando_worker.
     """
     def __init__(self, job_details, workflow, vm_instance_name):
         """
@@ -183,7 +184,7 @@ class RunJobPayload(object):
 
 class StoreJobOutputPayload(object):
     """
-    Payload that to be sent with JobCommands.STORE_JOB_OUTPUT to lando_worker.
+    Payload to be sent with JobCommands.STORE_JOB_OUTPUT to lando_worker.
     """
     def __init__(self, credentials, job_details, output_directory, vm_instance_name):
         """

--- a/lando_messaging/tests/test_clients.py
+++ b/lando_messaging/tests/test_clients.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+from unittest import TestCase
+from lando_messaging.clients import LandoWorkerClient, JobCommands
+from mock import MagicMock, patch
+
+
+class FakeJobDetails(object):
+    """
+    Can't mock this due to serialization
+    """
+    def __init__(self, id, name):
+        self.id = id
+        self.name = name
+
+
+class TestLandoWorkerClient(TestCase):
+    @patch('lando_messaging.clients.WorkQueueClient')
+    def test_stage_job(self, mock_work_queue_client):
+        lando_worker_client = LandoWorkerClient(MagicMock(), queue_name='lando')
+        job_details = FakeJobDetails(124, "FlyRNASeq2")
+        input_files = MagicMock()
+        lando_worker_client.stage_job(credentials='', job_details=job_details,
+                                             input_files=input_files, vm_instance_name='vm2')
+        args, kwargs = mock_work_queue_client().send.call_args
+        command = args[0]
+        job_run_payload = args[1]
+        self.assertEqual(JobCommands.STAGE_JOB, command)
+        self.assertEqual(124, job_run_payload.job_id)
+        self.assertEqual("FlyRNASeq2", job_run_payload.job_details.name)
+
+    @patch('lando_messaging.clients.WorkQueueClient')
+    def test_run_job(self, mock_work_queue_client):
+        lando_worker_client = LandoWorkerClient(MagicMock(), queue_name='lando')
+        job_details = FakeJobDetails(123, "FlyRNASeq")
+        workflow = MagicMock(url='', object_name='', job_order='', output_directory='')
+        lando_worker_client.run_job(job_details, workflow, vm_instance_name='vm1')
+        args, kwargs = mock_work_queue_client().send.call_args
+        command = args[0]
+        job_run_payload = args[1]
+        self.assertEqual(JobCommands.RUN_JOB, command)
+        self.assertEqual(123, job_run_payload.job_id)
+        self.assertEqual("FlyRNASeq", job_run_payload.job_details.name)
+
+    @patch('lando_messaging.clients.WorkQueueClient')
+    def test_store_job_output(self, mock_work_queue_client):
+        lando_worker_client = LandoWorkerClient(MagicMock(), queue_name='lando')
+        job_details = FakeJobDetails(125, "FlyRNASeq3")
+        output_directory = MagicMock(dir_name='', project_id='', dds_user_credentials='')
+        lando_worker_client.store_job_output(credentials='', job_details=job_details,
+                                             output_directory=output_directory, vm_instance_name='vm2')
+        args, kwargs = mock_work_queue_client().send.call_args
+        command = args[0]
+        job_run_payload = args[1]
+        self.assertEqual(JobCommands.STORE_JOB_OUTPUT, command)
+        self.assertEqual(125, job_run_payload.job_id)
+        self.assertEqual("FlyRNASeq3", job_run_payload.job_details.name)
+

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='lando_messaging',
-      version='0.2',
+      version='0.3',
       description='Lando workflow messaging component',
       url='https://github.com/Duke-GCB/lando-messaging',
       author='John Bradley',


### PR DESCRIPTION
Currently lando just passes the job id to the worker.
This change will add details about the job to the worker including job description, created dt/tm, etc.
Adding this to the __stage_job__, __run_job__ and __store_job__ messages.
It is only needed for changes in lando for the run_job and store_job messages.