### PR TITLE
Store output user/Adds version to messages

### DIFF
--- a/lando_messaging/clients.py
+++ b/lando_messaging/clients.py
@@ -129,14 +129,15 @@ class LandoWorkerClient(object):
         """
         self._send(JobCommands.RUN_JOB, RunJobPayload(job_details, workflow, vm_instance_name))
 
-    def store_job_output(self, credentials, job_details, vm_instance_name):
+    def store_job_output(self, credentials, job_details, vm_instance_name, share_with_user):
         """
         Store the output of a finished job.
         :param credentials: jobapi.Credentials: user's credentials used to upload resulting files
         :param job_details: object: details about job(id, name, created date, workflow version)
         :param vm_instance_name: name of the instance lando_worker is running on (this passed back in the response)
+        :param share_with_user: str: id representing the user to share the project with
         """
-        payload = StoreJobOutputPayload(credentials, job_details, vm_instance_name)
+        payload = StoreJobOutputPayload(credentials, job_details, vm_instance_name, share_with_user)
         self._send(JobCommands.STORE_JOB_OUTPUT, payload)
 
     def _send(self, command, payload):

--- a/lando_messaging/messaging.py
+++ b/lando_messaging/messaging.py
@@ -185,16 +185,18 @@ class StoreJobOutputPayload(object):
     """
     Payload to be sent with JobCommands.STORE_JOB_OUTPUT to lando_worker.
     """
-    def __init__(self, credentials, job_details, vm_instance_name):
+    def __init__(self, credentials, job_details, vm_instance_name, share_with_user):
         """
         :param credentials: jobapi.Credentials: user's credentials used to upload resulting files
         :param job_details: object: details about job(id, name, created date, workflow version)
         :param vm_instance_name: name of the instance lando_worker is running on (this passed back in the response)
+        :param share_with_user: str: id representing the user to share the project with
         """
         self.credentials = credentials
         self.job_id = job_details.id
         self.job_details = job_details
         self.vm_instance_name = vm_instance_name
+        self.share_with_user = share_with_user
         self.success_command = JobCommands.STORE_JOB_OUTPUT_COMPLETE
         self.error_command = JobCommands.STORE_JOB_OUTPUT_ERROR
         self.job_description = "Storing output files"

--- a/lando_messaging/tests/test_clients.py
+++ b/lando_messaging/tests/test_clients.py
@@ -46,11 +46,12 @@ class TestLandoWorkerClient(TestCase):
         lando_worker_client = LandoWorkerClient(MagicMock(), queue_name='lando')
         job_details = FakeJobDetails(125, "FlyRNASeq3")
         lando_worker_client.store_job_output(credentials='', job_details=job_details,
-                                             vm_instance_name='vm2')
+                                             vm_instance_name='vm2', share_with_user='joe@nope')
         args, kwargs = mock_work_queue_client().send.call_args
         command = args[0]
         job_run_payload = args[1]
         self.assertEqual(JobCommands.STORE_JOB_OUTPUT, command)
         self.assertEqual(125, job_run_payload.job_id)
         self.assertEqual("FlyRNASeq3", job_run_payload.job_details.name)
+        self.assertEqual('joe@nope', job_run_payload.share_with_user)
 

--- a/lando_messaging/tests/test_messaging.py
+++ b/lando_messaging/tests/test_messaging.py
@@ -122,7 +122,8 @@ class TestMessagingAndClients(TestCase):
         # Send message to fake_lando that a job failed while running
         lando_client.job_step_error(run_job_payload, "Oops2")
 
-        store_job_output_payload = StoreJobOutputPayload(None, FakeJobDetails(5), vm_instance_name='test')
+        store_job_output_payload = StoreJobOutputPayload(None, FakeJobDetails(5), vm_instance_name='test',
+                                                         share_with_user='joe@no.nope')
         # Send message to fake_lando that we finished storing output
         lando_client.job_step_store_output_complete(store_job_output_payload, output_project_info='project_id')
         # Send message to fake_lando that we had an error while storing output
@@ -147,7 +148,8 @@ class TestMessagingAndClients(TestCase):
         # job_step_complete should not be used with StoreJobOutputPayload
         queue_name = "lando"
         lando_client = LandoClient(self.config, queue_name)
-        store_job_output_payload = StoreJobOutputPayload(None, FakeJobDetails(5), vm_instance_name='test')
+        store_job_output_payload = StoreJobOutputPayload(None, FakeJobDetails(5), vm_instance_name='test',
+                                                         share_with_user='joe@no.nope')
         with self.assertRaises(ValueError):
             lando_client.job_step_complete(store_job_output_payload)
 
@@ -170,7 +172,8 @@ class TestMessagingAndClients(TestCase):
         lando_worker_client.stage_job(credentials=None, job_details=FakeJobDetails(1), input_files=[],
                                       vm_instance_name='test1')
         lando_worker_client.run_job(job_details=FakeJobDetails(2), workflow=FakeWorkflow(), vm_instance_name='test2')
-        lando_worker_client.store_job_output(credentials=None, job_details=FakeJobDetails(3), vm_instance_name='test3')
+        lando_worker_client.store_job_output(credentials=None, job_details=FakeJobDetails(3), vm_instance_name='test3',
+                                             share_with_user='joe@no.nope')
 
         router.run()
         self.assertEqual(fake_lando_worker.stage_job_payload.job_id, 1)
@@ -179,4 +182,5 @@ class TestMessagingAndClients(TestCase):
         self.assertEqual(fake_lando_worker.run_job_payload.vm_instance_name, 'test2')
         self.assertEqual(fake_lando_worker.store_job_output_payload.job_id, 3)
         self.assertEqual(fake_lando_worker.store_job_output_payload.vm_instance_name, 'test3')
+        self.assertEqual(fake_lando_worker.store_job_output_payload.share_with_user, 'joe@no.nope')
 

--- a/lando_messaging/tests/test_workqueue.py
+++ b/lando_messaging/tests/test_workqueue.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import
 from unittest import TestCase
+import pickle
 from lando_messaging.dockerutil import DockerRabbitmq
-from lando_messaging.workqueue import WorkQueueConnection, WorkQueueProcessor, WorkQueueClient, WorkProgressQueue
+from lando_messaging.workqueue import WorkQueueConnection, WorkQueueProcessor, WorkQueueClient, WorkProgressQueue, \
+    WorkRequest, get_version_str
+from mock import MagicMock, patch
 
 
 class FakeConfig(object):
@@ -90,3 +93,40 @@ class TestWorkProgressQueue(TestCase):
         result = wpq.send('{"job":16, "status":"GOOD"}')
         self.assertEqual(True, result)
 
+
+class TestGetVersionStr(TestCase):
+    def test_version(self):
+        version_str = get_version_str()
+        self.assertEqual(type(version_str), str)
+        parts = version_str.split(".")
+        self.assertRegexpMatches(version_str, '^\d+.\d+.\d+$')
+
+
+class TestWorkQueueProcessor(TestCase):
+    def setUp(self):
+        self.payload = None
+
+    def do_work(self, payload):
+        self.payload = payload
+
+    def test_default_mismatch_version_raises(self):
+        processor = WorkQueueProcessor(MagicMock(), 'test')
+        processor.add_command('dowork', self.do_work)
+        request = WorkRequest('dowork', 'somedata')
+        request.version = '0.0.0'
+        with self.assertRaises(ValueError) as err_context:
+            processor.process_message(MagicMock(), MagicMock(), None, pickle.dumps(request))
+        self.assertEqual(str(err_context.exception), 'Received version mismatch.')
+
+    def upgrade_payload(self, work_request, our_version):
+        work_request.payload = 'evenbetter'
+        work_request.version = our_version
+
+    def test_default_mismatch_version_with_override(self):
+        # We pretend to upgrade the request payload
+        processor = WorkQueueProcessor(MagicMock(), 'test', self.upgrade_payload)
+        processor.add_command('dowork', self.do_work)
+        request = WorkRequest('dowork', 'somedata')
+        request.version = '0.0.0'
+        processor.process_message(MagicMock(), MagicMock(), None, pickle.dumps(request))
+        self.assertEqual('evenbetter', self.payload)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='lando-messaging',
-      version='0.7.0',
+      version='0.7.1',
       description='Lando workflow messaging component',
       url='https://github.com/Duke-GCB/lando-messaging',
       author='John Bradley',


### PR DESCRIPTION
Adds user to share with to store_job_output message.
Adds version number to all messages and raises error by default.
Implementers can provide a function to try to upgrade messages.
