### PR TITLE
Add version number to messages

### DIFF
--- a/lando_messaging/tests/test_workqueue.py
+++ b/lando_messaging/tests/test_workqueue.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import
 from unittest import TestCase
+import pickle
 from lando_messaging.dockerutil import DockerRabbitmq
-from lando_messaging.workqueue import WorkQueueConnection, WorkQueueProcessor, WorkQueueClient, WorkProgressQueue
+from lando_messaging.workqueue import WorkQueueConnection, WorkQueueProcessor, WorkQueueClient, WorkProgressQueue, \
+    WorkRequest, get_version_str
+from mock import MagicMock, patch
 
 
 class FakeConfig(object):
@@ -90,3 +93,40 @@ class TestWorkProgressQueue(TestCase):
         result = wpq.send('{"job":16, "status":"GOOD"}')
         self.assertEqual(True, result)
 
+
+class TestGetVersionStr(TestCase):
+    def test_version(self):
+        version_str = get_version_str()
+        self.assertEqual(type(version_str), str)
+        parts = version_str.split(".")
+        self.assertRegexpMatches(version_str, '^\d+.\d+.\d+$')
+
+
+class TestWorkQueueProcessor(TestCase):
+    def setUp(self):
+        self.payload = None
+
+    def do_work(self, payload):
+        self.payload = payload
+
+    def test_default_mismatch_version_raises(self):
+        processor = WorkQueueProcessor(MagicMock(), 'test')
+        processor.add_command('dowork', self.do_work)
+        request = WorkRequest('dowork', 'somedata')
+        request.version = '0.0.0'
+        with self.assertRaises(ValueError) as err_context:
+            processor.process_message(MagicMock(), MagicMock(), None, pickle.dumps(request))
+        self.assertEqual(str(err_context.exception), 'Received version mismatch.')
+
+    def upgrade_payload(self, work_request, our_version):
+        work_request.payload = 'evenbetter'
+        work_request.version = our_version
+
+    def test_default_mismatch_version_with_override(self):
+        # We pretend to upgrade the request payload
+        processor = WorkQueueProcessor(MagicMock(), 'test', self.upgrade_payload)
+        processor.add_command('dowork', self.do_work)
+        request = WorkRequest('dowork', 'somedata')
+        request.version = '0.0.0'
+        processor.process_message(MagicMock(), MagicMock(), None, pickle.dumps(request))
+        self.assertEqual('evenbetter', self.payload)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='lando-messaging',
-      version='0.7.0',
+      version='0.7.1',
       description='Lando workflow messaging component',
       url='https://github.com/Duke-GCB/lando-messaging',
       author='John Bradley',


### PR DESCRIPTION
Adding version number to messages and will default to raising error
implementations can provide a function to upgrade message payloads