### PR TITLE
update to python3 and use pickle protocol version 2

### DIFF
--- a/lando_messaging/clients.py
+++ b/lando_messaging/clients.py
@@ -2,7 +2,7 @@
 Classes that simplify sending messages to the workqueue.
 These send messages that will be recevied by MessageRouter.
 """
-from __future__ import absolute_import
+
 from lando_messaging.messaging import JobCommands
 from lando_messaging.messaging import StartJobPayload, RestartJobPayload, CancelJobPayload
 from lando_messaging.messaging import JobStepCompletePayload, JobStepErrorPayload

--- a/lando_messaging/messaging.py
+++ b/lando_messaging/messaging.py
@@ -1,7 +1,7 @@
 """
 Defines all commands/payloads and a message receiver which allow lando and lando_worker to communicate over AMQP.
 """
-from __future__ import absolute_import
+
 from lando_messaging.workqueue import WorkQueueProcessor, DisconnectingWorkQueueProcessor
 
 

--- a/lando_messaging/tests/test_clients.py
+++ b/lando_messaging/tests/test_clients.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 from unittest import TestCase
 from lando_messaging.clients import LandoWorkerClient, JobCommands
 from mock import MagicMock, patch

--- a/lando_messaging/tests/test_messaging.py
+++ b/lando_messaging/tests/test_messaging.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 from unittest import TestCase, skipIf
 import os
 from lando_messaging.messaging import MessageRouter, LANDO_INCOMING_MESSAGES, LANDO_WORKER_INCOMING_MESSAGES

--- a/lando_messaging/tests/test_workqueue.py
+++ b/lando_messaging/tests/test_workqueue.py
@@ -4,7 +4,7 @@ import os
 import pickle
 from lando_messaging.workqueue import WorkQueueConnection, WorkQueueProcessor, WorkQueueClient, WorkProgressQueue, \
     WorkRequest, get_version_str, Config, DisconnectingWorkQueueProcessor
-from mock import MagicMock, patch, Mock
+from mock import MagicMock, patch, Mock, ANY
 
 INTEGRATION_TEST = os.environ.get('INTEGRATION_TEST') == 'true'
 
@@ -211,4 +211,5 @@ class WorkQueueClientTestCase(TestCase):
     def test_send_protocol_version(self, mock_pickle, mock_work_request, mock_work_queue_connection):
         client = WorkQueueClient(config=Mock(), queue_name='myqueue')
         client.send('test', 'data')
-        mock_pickle.dumps.assert_called_with(mock_work_request.return_value, protcol=2)
+        args, kwargs = mock_pickle.dumps.call_args
+        self.assertEqual(kwargs['protocol'], 2)

--- a/lando_messaging/workqueue.py
+++ b/lando_messaging/workqueue.py
@@ -1,7 +1,7 @@
 """
 Code for processing/sending messages from/to a queue(AMQP)
 """
-from __future__ import absolute_import
+
 import logging
 import pkg_resources
 import pika
@@ -164,7 +164,8 @@ class WorkQueueClient(object):
         """
         request = WorkRequest(command, payload)
         logging.info("Sending {} message to queue {}.".format(request.command, self.queue_name))
-        self.connection.send_durable_message(self.queue_name, pickle.dumps(request))
+        # setting protocol to version 2 to be compatible with python2
+        self.connection.send_durable_message(self.queue_name, pickle.dumps(request, protocol=2))
         logging.info("Sent {} message.".format(request.command, self.queue_name))
 
     def delete_queue(self):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='lando-messaging',
-      version='0.7.3',
+      version='0.7.4',
       description='Lando workflow messaging component',
       url='https://github.com/Duke-GCB/lando-messaging',
       author='John Bradley',


### PR DESCRIPTION
Explicitly sets protocol to 2 for `pickle.dump`.

Upgrades to python3 `2to3 -w lando/`
Incremented the version to `0.7.4`

Fixes #18 