### PR TITLE
Organize output message

### DIFF
--- a/lando_messaging/messaging.py
+++ b/lando_messaging/messaging.py
@@ -22,6 +22,10 @@ class JobCommands(object):
     RUN_JOB_COMPLETE = 'run_job_complete'                    # lando_worker -> lando
     RUN_JOB_ERROR = 'run_job_error'                          # lando_worker -> lando
 
+    # only for use with k8s lando/watcher
+    ORGANIZE_OUTPUT_COMPLETE = 'organize_output_complete'    # watcher -> lando
+    ORGANIZE_OUTPUT_ERROR = 'organize_output_error'          # watcher -> lando
+
     STORE_JOB_OUTPUT = 'store_job_output'                    # lando -> lando_worker
     STORE_JOB_OUTPUT_COMPLETE = 'store_job_output_complete'  # lando_worker -> lando
     STORE_JOB_OUTPUT_ERROR = 'store_job_output_error'        # lando_worker -> lando
@@ -38,7 +42,9 @@ LANDO_INCOMING_MESSAGES = [
     JobCommands.RUN_JOB_COMPLETE,
     JobCommands.RUN_JOB_ERROR,
     JobCommands.STORE_JOB_OUTPUT_COMPLETE,
-    JobCommands.STORE_JOB_OUTPUT_ERROR
+    JobCommands.STORE_JOB_OUTPUT_ERROR,
+    JobCommands.ORGANIZE_OUTPUT_COMPLETE,
+    JobCommands.ORGANIZE_OUTPUT_ERROR,
 ]
 
 # Commands that lando_worker will receive.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='lando-messaging',
-      version='0.7.4',
+      version='0.7.5',
       description='Lando workflow messaging component',
       url='https://github.com/Duke-GCB/lando-messaging',
       author='John Bradley',


### PR DESCRIPTION
Adds two messages (complete and error) for notifying lando about organizing output project. 
For https://github.com/Duke-GCB/lando/issues/137