### PR TITLE
Prevent message repeating when queue deleted

### DIFF
--- a/lando_messaging/workqueue.py
+++ b/lando_messaging/workqueue.py
@@ -319,6 +319,7 @@ class DisconnectingWorkQueueProcessor(WorkQueueProcessor):
         """
         while self.receiving_messages:
             # connect to AMQP server and listen for 1 message then disconnect
+            self.work_request = None
             self.connection.receive_loop_with_callback(self.queue_name, self.save_work_request_and_close)
             if self.work_request:
                 self.process_work_request()


### PR DESCRIPTION
Fixes issue in `DisconnectingWorkQueueProcessor` where the last message was sent again when the queue is deleted. The `receive_loop_with_callback` method will not call `save_work_request_and_close` if the queue is deleted but returns immediately. This causes duplicate messages. Changes here reset the work_request variable to prevent these spurious messages.

Fixes #24 