### PR TITLE
Adds start and cancel debugging messages

### DIFF
--- a/lando_messaging/clients.py
+++ b/lando_messaging/clients.py
@@ -10,6 +10,7 @@ from lando_messaging.messaging import JobStepStoreOutputCompletePayload
 from lando_messaging.messaging import StageJobPayload, RunJobPayload, StoreJobOutputPayload
 from lando_messaging.messaging import OrganizeOutputProjectPayload
 from lando_messaging.messaging import WorkerStartedPayload
+from lando_messaging.messaging import StartDebugPayload, CancelDebugPayload
 from lando_messaging.workqueue import WorkQueueClient
 
 
@@ -96,6 +97,21 @@ class LandoClient(object):
         """
         payload = JobStepErrorPayload(job_request_payload, message)
         self.send(job_request_payload.error_command, payload)
+
+
+    def start_debug(self, job_id):
+        """
+        Post a message in the queue to have a debug server created for a job.
+        :param job_id: int:  unique id for a job
+        """
+        self.send(JobCommands.START_DEBUG, StartDebugPayload(job_id))
+
+    def cancel_debug(self, job_id):
+        """
+        Post a message in the queue to delete the debug server for a job.
+        :param job_id: int:  unique id for a job
+        """
+        self.send(JobCommands.CANCEL_DEBUG, CancelDebugPayload(job_id))
 
 
 class LandoWorkerClient(object):

--- a/lando_messaging/messaging.py
+++ b/lando_messaging/messaging.py
@@ -34,6 +34,9 @@ class JobCommands(object):
     RECORD_OUTPUT_PROJECT_COMPLETE = 'record_output_project_complete'  # watcher -> lando
     RECORD_OUTPUT_PROJECT_ERROR = 'record_output_project_error'        # watcher -> lando
 
+    START_DEBUG = 'start_debug'                              # webserver -> lando
+    CANCEL_DEBUG = 'cancel_debug'                            # webserver -> lando
+
 
 # Commands that lando will receive.
 VM_LANDO_INCOMING_MESSAGES = [
@@ -73,6 +76,8 @@ K8S_LANDO_INCOMING_MESSAGES = [
     JobCommands.STORE_JOB_OUTPUT_ERROR,
     JobCommands.RECORD_OUTPUT_PROJECT_COMPLETE,
     JobCommands.RECORD_OUTPUT_PROJECT_ERROR,
+    JobCommands.START_DEBUG,
+    JobCommands.CANCEL_DEBUG,
 ]
 
 
@@ -297,3 +302,27 @@ class JobStepErrorPayload(object):
         self.job_id = payload.job_id
         self.vm_instance_name = payload.vm_instance_name
         self.message = message
+
+
+class StartDebugPayload(object):
+    """
+    Payload to be sent with JobCommands.START_DEBUG to lando.
+    """
+    def __init__(self, job_id, job_username):
+        """
+        :param job_id: int: job id we want to setup debugging for
+        """
+        self.job_id = job_id
+        self.job_username = job_username
+
+
+class CancelDebugPayload(object):
+    """
+    Payload to be sent with JobCommands.CANCEL_DEBUG to lando.
+    """
+
+    def __init__(self, job_id):
+        """
+        :param job_id: int: job id we want to have cancel debugging for
+        """
+        self.job_id = job_id

--- a/lando_messaging/messaging.py
+++ b/lando_messaging/messaging.py
@@ -308,12 +308,11 @@ class StartDebugPayload(object):
     """
     Payload to be sent with JobCommands.START_DEBUG to lando.
     """
-    def __init__(self, job_id, job_username):
+    def __init__(self, job_id):
         """
         :param job_id: int: job id we want to setup debugging for
         """
         self.job_id = job_id
-        self.job_username = job_username
 
 
 class CancelDebugPayload(object):

--- a/lando_messaging/tests/test_clients.py
+++ b/lando_messaging/tests/test_clients.py
@@ -1,7 +1,7 @@
 
 from unittest import TestCase
-from lando_messaging.clients import LandoWorkerClient, JobCommands
-from mock import MagicMock, patch
+from lando_messaging.clients import LandoWorkerClient, JobCommands, LandoClient
+from mock import MagicMock, patch, Mock
 
 
 class FakeJobDetails(object):
@@ -54,3 +54,26 @@ class TestLandoWorkerClient(TestCase):
         self.assertEqual(125, job_run_payload.job_id)
         self.assertEqual("FlyRNASeq3", job_run_payload.job_details.name)
 
+
+class TestLandoClient(TestCase):
+    @patch('lando_messaging.clients.WorkQueueClient')
+    @patch('lando_messaging.clients.StartDebugPayload')
+    def test_start_debug(self, mock_start_debug_payload, mock_work_queue_client):
+        client = LandoClient(Mock(), Mock())
+        client.start_debug(123)
+        mock_work_queue_client.return_value.send.assert_called_with(
+            JobCommands.START_DEBUG,
+            mock_start_debug_payload.return_value,
+        )
+        mock_start_debug_payload.assert_called_with(123)
+
+    @patch('lando_messaging.clients.WorkQueueClient')
+    @patch('lando_messaging.clients.CancelDebugPayload')
+    def test_cancel_debug(self, mock_cancel_debug_payload, mock_work_queue_client):
+        client = LandoClient(Mock(), Mock())
+        client.cancel_debug(123)
+        mock_work_queue_client.return_value.send.assert_called_with(
+            JobCommands.CANCEL_DEBUG,
+            mock_cancel_debug_payload.return_value,
+        )
+        mock_cancel_debug_payload.assert_called_with(123)

--- a/lando_messaging/tests/test_messaging.py
+++ b/lando_messaging/tests/test_messaging.py
@@ -244,3 +244,19 @@ class TestMessagingAndClients(TestCase):
         lando_worker_client.store_job_output(credentials=None, job_details=FakeJobDetails(3), vm_instance_name='test3')
 
         router.run()
+
+    def test_k8s_lando_router_start_debug(self):
+        mock_target = Mock()
+        router = MessageRouter.make_k8s_lando_router(self.config, mock_target, Mock())
+        work_request = Mock(version=router.processor.version, command=JobCommands.START_DEBUG)
+        router.processor.work_request = work_request
+        router.processor.process_work_request()
+        mock_target.start_debug.assert_called_with(work_request.payload)
+
+    def test_k8s_lando_router_cancel_debug(self):
+        mock_target = Mock()
+        router = MessageRouter.make_k8s_lando_router(self.config, mock_target, Mock())
+        work_request = Mock(version=router.processor.version, command=JobCommands.CANCEL_DEBUG)
+        router.processor.work_request = work_request
+        router.processor.process_work_request()
+        mock_target.cancel_debug.assert_called_with(work_request.payload)


### PR DESCRIPTION
Adds ability for bespin-api to send a message to lando requesting start/cancel debugging for a job.
